### PR TITLE
beryllium: Move qti-telephony-common jar to system_ext partition

### DIFF
--- a/overlay/packages/services/Telephony/res/xml/telephony_injection.xml
+++ b/overlay/packages/services/Telephony/res/xml/telephony_injection.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2019 The Linux Foundation. All rights reserved.
+  Not a Contribution.
+  Copyright (C) 2018 The Android Open Source Project
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- package: customized component factory to inject,
+        e.g. "example.package.exampleTelephonyComponentFactory"
+     jar: jar path to customized jar which contains exampleTelephonyComponentFactory to inject, and
+     "/system/framework/" should be the target directory.
+        e.g. "/system/framework/eg-telephony-common.jar"
+-->
+<injection package="com.qualcomm.qti.internal.telephony.QtiTelephonyComponentFactory"
+           jar="/system_ext/framework/qti-telephony-common.jar:/system/framework/qti-telephony-common.jar:/product/framework/qti-telephony-common.jar:/product/framework/qti-telephony-hidl-wrapper.jar:/product/framework/qti-telephony-utils.jar:/system/framework/qti-telephony-utils.jar">
+    <components>
+</injection>


### PR DESCRIPTION
Move qti-telephony-common jar to system_ext partition.